### PR TITLE
Added dynamic environment variable for API endpoint

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,10 +32,11 @@ function writeCookie() {
    document.cookie = "manual_location=" + cookievalue;
 }
 
-async function updatePage(survey_id){
+async function updatePage(){
     var repeater;
     var survey_id = $('.temp_information').data('survey-id')
-    const response = await fetch(`http://localhost:3000/api/v1/surveys/${survey_id}`, {});
+    var api_url = $('.temp_information').data('api-url')
+    const response = await fetch(`http://${api_url}/api/v1/surveys/${survey_id}`, {});
     const json = await response.json();
     var total_votes = json.data.attributes.total_votes;
     var restaurant_1_votes = json.data.attributes.restaurant_1_votes;

--- a/app/views/surveys/show.html.erb
+++ b/app/views/surveys/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, class: "temp_information", data: {survey_id: survey_id} do %>
+<%= content_tag :div, class: "temp_information", data: {survey_id: survey_id, api_url: ENV["API_URL"]} do %>
 <% end %>
 
 <script>


### PR DESCRIPTION
This should make it so that the API endpoint for survey results is dynamically generated depending on whether or not the app is being run in production mode.

You will need to add the following to your application.yml file:
```
API_URL: localhost:3000
production:
  API_URL: calm-tundra-59037.herokuapp.com
```