### PR TITLE
Updated javascript to reload show page if survey is inactive

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,10 +43,14 @@ async function updatePage(){
     var restaurant_1_votes = json.data.attributes.restaurant_1_votes;
     var restaurant_2_votes = json.data.attributes.restaurant_2_votes;
     var restaurant_3_votes = json.data.attributes.restaurant_3_votes;
+    var survey_status = json.data.attributes.survey_status
 
     document.getElementById("total-votes").innerHTML=total_votes;
     document.getElementById("sr1-votes").innerHTML=restaurant_1_votes;
     document.getElementById("sr2-votes").innerHTML=restaurant_2_votes;
     document.getElementById("sr3-votes").innerHTML=restaurant_3_votes;
     repeater = setTimeout(updatePage, 3000);
+    if (survey_status == 'inactive') {
+      location.reload()
+    }
   };

--- a/app/serializers/survey_serializer.rb
+++ b/app/serializers/survey_serializer.rb
@@ -5,6 +5,9 @@ class SurveySerializer
   attribute :total_votes do |survey|
     survey.votes.count
   end
+  attribute :survey_status do |survey|
+    survey.status
+  end
   attribute :restaurant_1_votes do |survey|
     survey.survey_restaurants[0].votes.count unless survey.survey_restaurants.empty?
   end


### PR DESCRIPTION
This change to the javascript should check if the survey has been ended after updating the vote fields, and if so, it will refresh the page. 